### PR TITLE
perf: test nesting level only once

### DIFF
--- a/src/utils/json/mod.rs
+++ b/src/utils/json/mod.rs
@@ -38,12 +38,13 @@ pub fn flatten_json_body(
     validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
     // Flatten the json body only if new schema and has less than 4 levels of nesting
-    let mut nested_value = if schema_version == SchemaVersion::V0 || has_more_than_four_levels(&body, 1) {
-        body
-    } else {
-        let flattened_json = generic_flattening(&body)?;
-        convert_to_array(flattened_json)?
-    };
+    let mut nested_value =
+        if schema_version == SchemaVersion::V0 || has_more_than_four_levels(&body, 1) {
+            body
+        } else {
+            let flattened_json = generic_flattening(&body)?;
+            convert_to_array(flattened_json)?
+        };
     flatten::flatten(
         &mut nested_value,
         "_",


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes https://github.com/parseablehq/parseable/pull/1058.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

In this branch we perform the nesting level check at every level of nesting that we traverse with `generic_flattening`, which is unnecessary as a single test at the starting would be enough, which is what the change proposes to do.

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
